### PR TITLE
Add method to retrieve a state by its code

### DIFF
--- a/src/ShowsOnSale.World/WorldData.Methods.cs
+++ b/src/ShowsOnSale.World/WorldData.Methods.cs
@@ -51,4 +51,26 @@ public partial class WorldData
                 .OrderBy(t => t.ZoneName);
         }
     }
+    
+    /// <summary>
+    /// Gets a state by its code.
+    /// </summary>
+    /// <param name="countryCode">The ISO2 or ISO3 code of the country.</param>
+    /// <param name="stateCode">The ISO2 code of the state.</param>
+    /// <returns>The state if found; otherwise, null.</returns>
+    public static Models.State? GetStateByCode(string countryCode, string stateCode)
+    {
+        if (string.IsNullOrWhiteSpace(countryCode) || string.IsNullOrWhiteSpace(stateCode))
+            return null;
+
+        countryCode = countryCode.Trim().ToUpperInvariant();
+        stateCode = stateCode.Trim().ToUpperInvariant();
+
+        var country = WorldData.GetCountryByCode(countryCode);
+        if (country == null)
+            return null;
+
+        return country.States.FirstOrDefault(s =>
+            string.Equals(s.StateCode, stateCode, StringComparison.OrdinalIgnoreCase));
+    }
 }


### PR DESCRIPTION
Introduced the `GetStateByCode` method to fetch a state's details based on its ISO2 code and the associated country code. This adds the functionality of retrieving state-specific data within the WorldData class.